### PR TITLE
Use shell instead of exec entrypoints

### DIFF
--- a/build/docker/agent/Dockerfile
+++ b/build/docker/agent/Dockerfile
@@ -6,7 +6,8 @@ RUN FORCE_REBUILD=1 GOOS=linux GOARCH=amd64 make build-${COMPONENT}
 
 FROM alpine:latest
 ARG COMPONENT
+ENV COMPONENT=${COMPONENT}
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /workspace/bin/${COMPONENT} /usr/local/bin/${COMPONENT}
-ENTRYPOINT ["/usr/local/bin/${COMPONENT}"]
+ENTRYPOINT "/usr/local/bin/${COMPONENT}"
 CMD ["run"]

--- a/build/docker/agent/Dockerfile.circleci
+++ b/build/docker/agent/Dockerfile.circleci
@@ -3,7 +3,8 @@ RUN apk add --no-cache ca-certificates
 
 FROM alpine:latest
 ARG COMPONENT
+ENV COMPONENT=${COMPONENT}
 COPY --from=vendor /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY bin/${COMPONENT} /usr/local/bin/${COMPONENT}
-ENTRYPOINT ["/usr/local/bin/${COMPONENT}"]
+ENTRYPOINT "/usr/local/bin/${COMPONENT}"
 CMD ["run"]

--- a/build/docker/cli/Dockerfile
+++ b/build/docker/cli/Dockerfile
@@ -6,6 +6,7 @@ RUN FORCE_REBUILD=1 GOOS=linux GOARCH=amd64 make build-${COMPONENT}
 
 FROM alpine:latest
 ARG COMPONENT
+ENV COMPONENT=${COMPONENT}
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /workspace/bin/${COMPONENT} /usr/local/bin/${COMPONENT}
-ENTRYPOINT ["/usr/local/bin/${COMPONENT}"]
+ENTRYPOINT "/usr/local/bin/${COMPONENT}"

--- a/build/docker/cli/Dockerfile.circleci
+++ b/build/docker/cli/Dockerfile.circleci
@@ -3,6 +3,7 @@ RUN apk add --no-cache ca-certificates
 
 FROM alpine:latest
 ARG COMPONENT
+ENV COMPONENT=${COMPONENT}
 COPY --from=vendor /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY bin/${COMPONENT} /usr/local/bin/${COMPONENT}
-ENTRYPOINT ["/usr/local/bin/${COMPONENT}"]
+ENTRYPOINT "/usr/local/bin/${COMPONENT}"

--- a/build/docker/grpc-server/Dockerfile
+++ b/build/docker/grpc-server/Dockerfile
@@ -8,9 +8,10 @@ RUN FORCE_REBUILD=1 GOOS=linux GOARCH=amd64 make build-${COMPONENT} \
 
 FROM alpine:latest
 ARG COMPONENT
+ENV COMPONENT=${COMPONENT}
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /usr/local/bin/grpc_health_probe /usr/local/bin/grpc_health_probe
 COPY --from=builder /workspace/bin/${COMPONENT} /usr/local/bin/${COMPONENT}
-ENTRYPOINT ["/usr/local/bin/${COMPONENT}"]
+ENTRYPOINT "/usr/local/bin/${COMPONENT}"
 CMD ["serve"]
 EXPOSE 8080/tcp 9090/tcp

--- a/build/docker/grpc-server/Dockerfile.circleci
+++ b/build/docker/grpc-server/Dockerfile.circleci
@@ -5,9 +5,10 @@ RUN apk add --no-cache ca-certificates \
 
 FROM alpine:latest
 ARG COMPONENT
+ENV COMPONENT=${COMPONENT}
 COPY --from=vendor /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=vendor /usr/local/bin/grpc_health_probe /usr/local/bin/grpc_health_probe
 COPY bin/${COMPONENT} /usr/local/bin/${COMPONENT}
-ENTRYPOINT ["/usr/local/bin/${COMPONENT}"]
+ENTRYPOINT "/usr/local/bin/${COMPONENT}"
 CMD ["serve"]
 EXPOSE 8080/tcp 9090/tcp

--- a/build/docker/integration/Dockerfile
+++ b/build/docker/integration/Dockerfile
@@ -6,8 +6,9 @@ RUN FORCE_REBUILD=1 GOOS=linux GOARCH=amd64 make build-powerssl-integration-${IN
 
 FROM alpine:latest
 ARG INTEGRATION
+ENV INTEGRATION=${INTEGRATION}
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /workspace/bin/powerssl-integration-${INTEGRATION} /usr/local/bin/powerssl-integration-${INTEGRATION}
-ENTRYPOINT ["/usr/local/bin/powerssl-integration-${INTEGRATION}"]
+ENTRYPOINT "/usr/local/bin/powerssl-integration-${INTEGRATION}"
 CMD ["run"]
 EXPOSE 9090/tcp

--- a/build/docker/integration/Dockerfile.circleci
+++ b/build/docker/integration/Dockerfile.circleci
@@ -3,8 +3,9 @@ RUN apk add --no-cache ca-certificates
 
 FROM alpine:latest
 ARG INTEGRATION
+ENV INTEGRATION=${INTEGRATION}
 COPY --from=vendor /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY bin/powerssl-integration-${INTEGRATION} /usr/local/bin/powerssl-integration-${INTEGRATION}
-ENTRYPOINT ["/usr/local/bin/powerssl-integration-${INTEGRATION}"]
+ENTRYPOINT "/usr/local/bin/powerssl-integration-${INTEGRATION}"
 CMD ["run"]
 EXPOSE 9090/tcp

--- a/build/docker/web-server/Dockerfile
+++ b/build/docker/web-server/Dockerfile
@@ -6,8 +6,9 @@ RUN FORCE_REBUILD=1 GOOS=linux GOARCH=amd64 make build-${COMPONENT}
 
 FROM alpine:latest
 ARG COMPONENT
+ENV COMPONENT=${COMPONENT}
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /workspace/bin/${COMPONENT} /usr/local/bin/${COMPONENT}
-ENTRYPOINT ["/usr/local/bin/${COMPONENT}"]
+ENTRYPOINT "/usr/local/bin/${COMPONENT}"
 CMD ["serve"]
 EXPOSE 8080/tcp 9090/tcp

--- a/build/docker/web-server/Dockerfile.circleci
+++ b/build/docker/web-server/Dockerfile.circleci
@@ -3,8 +3,9 @@ RUN apk add --no-cache ca-certificates
 
 FROM alpine:latest
 ARG COMPONENT
+ENV COMPONENT=${COMPONENT}
 COPY --from=vendor /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY bin/${COMPONENT} /usr/local/bin/${COMPONENT}
-ENTRYPOINT ["/usr/local/bin/${COMPONENT}"]
+ENTRYPOINT "/usr/local/bin/${COMPONENT}"
 CMD ["serve"]
 EXPOSE 8080/tcp 9090/tcp


### PR DESCRIPTION
Exec entrypoints are not able to resolve environment variables which
results in broken binary path.