### PR TITLE
temporal dependency notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Developing PowerSSL
 
 If you wish to work on PowerSSL itself or any of its built-in systems, you'll
 first need [Go](https://www.golang.org) installed on your machine (version
-1.13+ is *required*).
+1.13+ is *required*). Ensure *gcc-5* package is installed as its a required build dependency.
 
 You can then download any required build tools by bootstrapping your environment:
 


### PR DESCRIPTION
Tried to build the project and got an error that I need gcc-5 to build.

- Add build dependency notice to README

Please ignore the "temporal" in branch name.
Just used it to remember the merge branch.